### PR TITLE
$trialEnd variable has to be a Carbon Object. Return Conekta subscription response on create

### DIFF
--- a/src/Dinkbit/ConektaCashier/ConektaGateway.php
+++ b/src/Dinkbit/ConektaCashier/ConektaGateway.php
@@ -203,9 +203,11 @@ class ConektaGateway
     /**
      * Extend a subscription trial end datetime.
      *
+     * @param \Carbon\Carbon $trialEnd
+
      * @return void
      */
-    public function extendTrial(\Datetime $trialEnd)
+    public function extendTrial(\Carbon\Carbon $trialEnd)
     {
         $customer = $this->getConektaCustomer();
 
@@ -421,11 +423,11 @@ class ConektaGateway
     /**
      * Specify the ending date of the trial.
      *
-     * @param \DateTime $trialEnd
+     * @param \Carbon\Carbon $trialEnd
      *
      * @return \Dinkbit\ConektaCashier\ConektaGateway
      */
-    public function trialFor(\DateTime $trialEnd)
+    public function trialFor(\Carbon\Carbon $trialEnd)
     {
         $this->trialEnd = $trialEnd;
 

--- a/src/Dinkbit/ConektaCashier/ConektaGateway.php
+++ b/src/Dinkbit/ConektaCashier/ConektaGateway.php
@@ -96,7 +96,7 @@ class ConektaGateway
      * @param array       $properties
      * @param object|null $customer
      *
-     * @return void
+     * @return \Conekta_Subscription|null
      */
     public function create($token, array $properties = [], $customer = null)
     {
@@ -121,6 +121,12 @@ class ConektaGateway
         }
 
         $this->updateLocalConektaData($customer);
+
+        if ($customer->subscription) {
+            return $customer->subscription;
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/src/Dinkbit/ConektaCashier/ConektaGateway.php
+++ b/src/Dinkbit/ConektaCashier/ConektaGateway.php
@@ -210,7 +210,7 @@ class ConektaGateway
      * Extend a subscription trial end datetime.
      *
      * @param \Carbon\Carbon $trialEnd
-
+     *
      * @return void
      */
     public function extendTrial(\Carbon\Carbon $trialEnd)


### PR DESCRIPTION
$trialEnd is supposed to be a \Carbon\Carbon instance, but sometimes it is requested as \Datetime and the function toIso8601String is not valid that way.

Also on the other commits, the crate function for subscription now returns the response from conekta, so we don't have to wait for a external webhook management.
